### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <dealog-common.version>1.0.0-SNAPSHOT</dealog-common.version>
-    <guava.version>30.0-jre</guava.version>
-    <lombok.version>1.18.16</lombok.version>
+    <guava.version>30.1.1-jre</guava.version>
+    <lombok.version>1.18.20</lombok.version>
     <lorem.version>2.1</lorem.version>
     <maven.compiler.version>3.8.1</maven.compiler.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -19,8 +19,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.9.2.Final</quarkus.platform.version>
-    <quarkus-plugin.version>1.9.2.Final</quarkus-plugin.version>
+    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
- Upgrade to Quarkus 1.13.6.Final
- Update guava from 30.0-jre to 30.1.1-jre
- Update lombok from 1.18.16 to 1.18.206