### PR TITLE
Bump Quarkus version and replace kafka w/ RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 1.0.0 (under development)
-This is the initial version
+## 2.0.0
+- Change reactive messaging from kafka to amqp 
+- Bump Quarkus from 1.13.6.Final to 2.2.2.Final
 
+## 1.0.0
 - 'NEW' Add mock that returns CAP messages
 - 'NEW' Add organisation and a random ars
 - 'CNG' Raise quarkus version to 1.9.2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ prerequisites needed to get the application up and running locally.
 ### Requirements
 
 - [Maven](https://maven.apache.org/) for building the project
-- [Apache Kafka](https://kafka.apache.org)
+- [RabbitMQ](https://www.rabbitmq.com)
 - [OpenJDK >= 11.0.x](https://openjdk.java.net/) to develop and deploy the application
 - [Docker](https://docker.io) for running the code
 - Editor for coding
@@ -24,7 +24,7 @@ prerequisites needed to get the application up and running locally.
 
 ### ... in dev mode
 
-Start an Apache Kafka. You can use DEalog Kafka Development Cluster e.g. the (https://github.com/DEalog/dealog-kafka-dev-cluster)
+Start an RabbitMQ with AMQP 1.0 plugin. You can use DEalog RabbitMQ Dockerfile e.g. the (https://github.com/DEalog/rabbitmq-amqp1)
 
 You can run your application in dev mode that enables live coding using:
 ```
@@ -63,6 +63,6 @@ If you want to collaborate please follow this guide:
 The DEalog Message service uses the following (main) technologies, frameworks and libraries:
 
 - [Quarkus](https://quarkus.io/)
-- [Apache Kafka](https://kafka.apache.org)
+- [RabbitMQ](https://www.rabbitmq.com)
 - [Project Lombok](https://projectlombok.org/)
 - [Lorem Ipsum generator for Java](https://github.com/mdeanda/lorem)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>de.dealog</groupId>
   <artifactId>dealog-message-generator</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <dealog-common.version>1.0.0-SNAPSHOT</dealog-common.version>
@@ -19,9 +19,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
     <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-    <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    <rxjava.version>2.2.21</rxjava.version>
+    <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -52,13 +53,17 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+      <artifactId>quarkus-smallrye-reactive-messaging-amqp</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-logging-json</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.reactivex.rxjava2</groupId>
+      <artifactId>rxjava</artifactId>
+      <version>${rxjava.version}</version>
+    </dependency>
     <dependency>
       <groupId>de.dealog</groupId>
       <artifactId>dealog-common</artifactId>

--- a/src/main/java/de/dealog/msg/messaging/MessageEventGenerator.java
+++ b/src/main/java/de/dealog/msg/messaging/MessageEventGenerator.java
@@ -6,14 +6,13 @@ import de.dealog.common.messaging.message.MessageEvent;
 import de.dealog.common.messaging.message.MessageEventPayload;
 import de.dealog.common.messaging.message.MessageEventType;
 import io.reactivex.Flowable;
-import lombok.extern.slf4j.Slf4j;
-import org.eclipse.microprofile.reactive.messaging.Outgoing;
-
-import javax.enterprise.context.ApplicationScoped;
 import java.util.Date;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import javax.enterprise.context.ApplicationScoped;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
 /**
  * A bean producing message events every 5 seconds. The message events are written to a Kafka topic (messages).
@@ -26,12 +25,12 @@ public class MessageEventGenerator {
 
     private static Random rand = new Random();
 
-    @Outgoing("generated-messages")
+    @Outgoing("messages")
     public Flowable<MessageEvent> generate() {
         log.debug("Generate");
 
         return Flowable.interval(5, TimeUnit.SECONDS)
-                .map(messageEvent -> nextMessageEvent());
+                .map(aLong -> nextMessageEvent());
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,14 +6,14 @@ quarkus.log.category."de.dealog".level=DEBUG
 quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 quarkus.log.console.level=DEBUG
-quarkus.log.console.color=false
 
 quarkus.log.category."io.quarkus".level=DEBUG
 
 %dev.quarkus.log.console.json=false
 %test.quarkus.log.console.json=false
 
-# Configure the Kafka sink (we write to it)
-mp.messaging.outgoing.generated-messages.connector=smallrye-kafka
-mp.messaging.outgoing.generated-messages.topic=messages
-mp.messaging.outgoing.generated-messages.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
+amqp-host=localhost
+amqp-port=5672
+mp.messaging.outgoing.messages.connector=smallrye-amqp
+mp.messaging.outgoing.messages.address=messages
+mp.messaging.outgoing.messages.use-anonymous-sender=false


### PR DESCRIPTION
- Change reactive messaging from kafka to amqp
- Bump Quarkus from 1.13.6.Final to 2.2.2.Final